### PR TITLE
Refine job logging with 'loop and sweep' mechanism

### DIFF
--- a/cascade/job_logs.md
+++ b/cascade/job_logs.md
@@ -1,35 +1,44 @@
 <!-- @meta {
   "fileType": "structural",
   "subtype": "index",
-  "purpose": "Manifest for job-log buffers; governs retention of recent job plans and their archival into a permanent ledger.",
+  "purpose": "Manifest for job-log files; defines the lifecycle of job information from current planning, to recent history, to a permanent archive.",
   "editPolicy": "appendOrReplace",
   "routeScope": "global",
   "mergeTarget": "job_logs/summary.md",
   "maxEntries": 5
 } -->
 ### /cascade/job_logs.md
-> **Role:** Tracks every WRITE-phase job plan.
-> * **`recent.md`** – rolling buffer (last 5 jobs).
-> * **`summary.md`** – infinite, append-only archive.
+> **Role:** Defines the structured process for logging AI job plans and their outcomes. This involves three key files:
+> * **`temp_job.md`**: Contains the plan for the single, currently active or most recently defined job. It is overwritten with each new job.
+> * **`job_logs/recent.md`**: A buffer that collects summaries of recently completed jobs. Once it reaches `maxEntries` (e.g., 5 jobs), its contents are swept to `job_logs/summary.md`.
+> * **`job_logs/summary.md`**: A permanent, append-only archive of all job summaries, providing a complete historical record.
 ---
-#### Active Buffers
-| File            | Class    | Retention (loops) | Notes                                  |
-|-----------------|----------|-------------------|----------------------------------------|
-| `recent.md`     | rolling  | **5**             | FIFO; overflows merge into archive     |
-| `summary.md`    | archive  | ∞ (append-only)   | Permanent ledger of all executed jobs  |
+#### Job Log Files & Lifecycle
+| File Path               | Role & Behavior                                                                                                | Max Entries (if applicable) | Edit Policy      |
+|-------------------------|----------------------------------------------------------------------------------------------------------------|-----------------------------|------------------|
+| `temp_job.md`           | Current job plan; overwritten each cycle by the AI during the ACT phase.                                       | 1 (conceptual)              | `overwrite`      |
+| `job_logs/recent.md`    | Buffer for summaries of recently completed jobs. Appended to after each job. When full, all entries are swept to `summary.md` and this file is cleared. | 5 (as per metadata)         | `appendOnly`     |
+| `job_logs/summary.md`   | Permanent append-only archive. Receives batches of job summaries from `recent.md`.                               | N/A                         | `appendOnly`     |
+
 ---
-#### Buffer Rules
-**`recent.md`**
-- `maxEntries`: **5** (also set in metadata).
-- Overflow: oldest row copied to `summary.md`, then evicted.
-- Edit policy: `appendOnly`; system controls eviction.
-**`summary.md`**
-- Append-only, chronological order.
-- Accepts rows flushed from `recent.md`.
-- Validator enforces monotonic timestamps + unique `jobId`.
+#### Buffer Management for `job_logs/recent.md`
+- **Population**: After a job defined in `temp_job.md` is successfully completed, a summary of that job (intent, key outcomes, status) is appended as a new entry to `job_logs/recent.md`.
+- **`maxEntries`**: The metadata field `maxEntries` (e.g., 5) in this file (`job_logs.md`) and/or in `job_logs/recent.md` defines the capacity of the recent jobs buffer.
+- **Sweep Operation (Trigger for Archival)**:
+    1. This operation is triggered when the number of job summaries in `job_logs/recent.md` reaches `maxEntries`.
+    2. All accumulated job summaries are read from `job_logs/recent.md`.
+    3. These summaries are then appended in chronological order to `job_logs/summary.md`.
+    4. `job_logs/recent.md` is then cleared of these entries (e.g., overwritten with its initial header or an empty state) to begin collecting the next batch of job summaries.
+- **Edit Policy**: `job_logs/recent.md` is `appendOnly` for individual job summaries. The sweep and clear operation is a system-level action.
+
 ---
-#### Merge Triggers
-1. `recent.md` exceeds **5** entries.
-2. Job plan sets `forceMerge: true`.
-3. Domain hits `merge_threshold` (see `/protocols/file_lifespans.md`).
+#### `job_logs/summary.md`
+- **Integrity**: This file is strictly append-only to maintain a tamper-evident historical record.
+- **Content**: Contains all job summaries that have been swept from `job_logs/recent.md`. Timestamps or sequential job IDs should ensure chronological order.
+
+---
+#### Guiding Principles for AI
+- The AI must follow the operational protocol defined in `/cascade/protocols/loop_protocol.md` for updating these job log files.
+- `temp_job.md` is the source for the current job's execution and its subsequent summarization into `job_logs/recent.md`.
+- The sweep from `job_logs/recent.md` to `job_logs/summary.md` is a critical step for maintaining context efficiency and historical integrity.
 ---

--- a/cascade/job_logs/recent.md
+++ b/cascade/job_logs/recent.md
@@ -1,7 +1,7 @@
 <!-- @meta {
   "fileType": "rolling",
   "subtype": "buffer",
-  "purpose": "A rolling log of the most recent job plan summaries, up to a defined maximum.",
+  "purpose": "A buffer for collecting summaries of recently completed jobs, up to 'maxEntries'. Once full, its contents are swept to the main summary log.",
   "editPolicy": "appendOnly",
   "routeScope": "global",
   "maxEntries": 5,
@@ -9,13 +9,25 @@
 } -->
 # Recent Job Logs
 
-This file contains a rolling buffer of summaries from recently executed job plans (from `temp_job.md`). When this log exceeds `maxEntries` (5), the oldest entry is moved to `/cascade/job_logs/summary.md`.
+This file serves as a temporary buffer, collecting summaries of recently executed job plans (derived from `temp_job.md` after successful completion). New job summaries are appended to this file by the AI.
 
-Each entry should summarize a completed job, including:
-- Job ID (could be a timestamp or a unique hash of the plan).
-- Intent of the job.
-- Key files affected.
-- Status (e.g., success, failed, rolled_back).
+**Lifecycle:**
+1.  **Collection:** Summaries of completed jobs are appended here.
+2.  **Capacity Check:** After each append, the system checks if the number of job summaries has reached `maxEntries` (defined in this file's metadata, e.g., 5).
+3.  **Sweep Operation:** If `maxEntries` is reached:
+    *   All job summaries currently in this file are read.
+    *   These summaries are appended to `/cascade/job_logs/summary.md`.
+    *   This `recent.md` file is then cleared of these entries (e.g., overwritten with this header or an empty state) to begin collecting the next batch.
+
+This process ensures that `recent.md` contains only a limited number of the most recent job summaries, while `summary.md` maintains the complete historical archive.
+
+**Entry Format:**
+Each appended entry should be a concise summary of a completed job, typically including:
+- Job ID (e.g., timestamp, unique hash of the plan, or sequential number).
+- Stated `intent` of the job.
+- Key files affected or key outcomes.
+- Final `status` (e.g., success, failed, rolled_back).
+- Timestamp of completion.
 
 ---
-*(No job summaries yet)*
+*(No job summaries yet. This file will be populated with job summaries. Once it reaches maxEntries, its content will be moved to summary.md and this area will be cleared.)*

--- a/cascade/job_logs/summary.md
+++ b/cascade/job_logs/summary.md
@@ -1,23 +1,25 @@
 <!-- @meta {
   "fileType": "append-only",
-  "purpose": "A permanent, append-only historical log of all job plan summaries, including those rolled over from job_logs/recent.md.",
+  "purpose": "A permanent, append-only historical log of all job plan summaries. It receives batches of summaries from the 'recent.md' buffer.",
   "editPolicy": "appendOnly",
   "routeScope": "global"
 } -->
 # Job Logs Summary
 
-This file is an append-only historical ledger of all executed job plan summaries. It includes entries merged from `/cascade/job_logs/recent.md` when that buffer reaches its `maxEntries` limit.
+This file is an append-only historical ledger of all executed job plan summaries. Its primary role is to serve as a long-term archive.
+
+It receives **batches of job summaries** that are "swept" from `/cascade/job_logs/recent.md` when that buffer reaches its `maxEntries` capacity. This ensures that `summary.md` grows chronologically with sets of recent activities.
 
 ---
 ## Guidelines
-- Entries are added chronologically.
-- Existing entries must not be modified or deleted.
-- Each entry should provide a concise summary of an executed job plan, typically including:
-    - Job ID or reference to the original `temp_job.md` (e.g., its hash or timestamp).
+- Entries (which are typically batches of summaries from `recent.md`) are appended chronologically.
+- Existing content in this file must not be modified or deleted to maintain historical integrity.
+- Each job summary within a batch should provide a concise record of an executed job plan, typically including:
+    - Job ID (e.g., timestamp, unique hash of the plan, or sequential number).
     - The stated `intent` of the job.
-    - A list of key files targeted by the job.
+    - Key files affected or key outcomes.
     - The final `status` of the job (e.g., success, failure, rolled_back).
-    - Timestamp of execution.
+    - Timestamp of completion.
 
 ---
-*(No job summaries yet)*
+*(No job summaries yet. This file will be populated with batches of job summaries swept from /cascade/job_logs/recent.md.)*


### PR DESCRIPTION
Updated the ContextCascade documentation to implement a more explicit 'loop and sweep' mechanism for job logging.

Key changes:
- `temp_job.md` stores the current job plan.
- `job_logs/recent.md` buffers a fixed number of completed job summaries.
- When `job_logs/recent.md` reaches `maxEntries`, its content is swept to `job_logs/summary.md` (the historical archive), and `job_logs/recent.md` is cleared.

Files updated:
- `cascade/job_logs.md` (manifest for job logs)
- `cascade/job_logs/recent.md` (internal description)
- `cascade/job_logs/summary.md` (internal description)
- `cascade/protocols/loop_protocol.md` (AI operational logic)
- `Repo_Documentation_v1.md` (comprehensive system documentation)